### PR TITLE
Serve the city calendar on this domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Google Calendar. Runs at [gdzienawesta.com](https://gdzienawesta.com).
   configured city says so and lists the ones that exist.
 - **The next three events**, swipeable, with a live countdown and buttons to
   add the event to a calendar or navigate to the venue.
-- **`/kalendarz` and `/calendar`** send you to the current city's Google
-  Calendar, so you can subscribe to it in your own.
+- **`/kalendarz` and `/calendar`** show the city's whole calendar, and
+  **`/kalendarz.ics` and `/calendar.ics`** are the same calendar as a feed to
+  subscribe to. Subscribers get an address on this domain rather than a Google
+  one, so the calendar behind a city can change without anyone resubscribing.
 - **Polish and English**, detected from the browser and switchable, with a
   preference remembered between visits.
 - **Times in the visitor's own timezone**, wherever they are.
@@ -25,6 +27,11 @@ No Google API keys and no OAuth: events come from each calendar's **public
 iCal feed** (`calendar.google.com/calendar/ical/<id>/public/basic.ics`), which
 is parsed server-side with `icalendar` + `recurring_ical_events` so recurring
 events, cancellations and per-occurrence changes all land correctly.
+
+Each calendar is fetched **at most every 15 minutes** and shared by everything that
+needs it — the pages, the API and the subscription feed. All of it leaves from
+the server's one address, so the alternative was traffic to Google that grew
+with the site's own popularity.
 
 Which city a request is for is decided from the `Host` header
 (`events/middleware.py`); an unrecognised host falls back to the default city,
@@ -80,19 +87,21 @@ be exercised locally without touching `/etc/hosts` — see
 │   │   ├── models.py       # City: name, slug, calendar id, default flag
 │   │   ├── middleware.py   # Host header -> city
 │   │   ├── services.py     # iCal fetching and recurrence expansion
-│   │   ├── views.py        # API endpoints and calendar redirects
+│   │   ├── views.py        # API endpoints and the calendar feed
 │   │   ├── slugs.py        # city name -> ASCII subdomain label
 │   │   └── tests.py
 │   └── westnfound/         # Django settings and URLs
 ├── frontend/
 │   ├── index.html
+│   ├── calendar.html       # the calendar page, both spellings of the path
 │   ├── app.js              # Alpine.js logic
+│   ├── calendar.js         # Alpine.js logic for the calendar page
 │   ├── translations.js     # PL/EN strings
 │   ├── styles.css
 │   ├── nginx.dev.conf
 │   └── nginx.prod.conf
 └── scripts/
-    └── stamp-assets.py     # cache-busting version stamps for CSS and JS
+    └── stamp-assets.py     # cache-busting version stamps for every page
 ```
 
 ## Tests

--- a/backend/events/services.py
+++ b/backend/events/services.py
@@ -1,13 +1,96 @@
 from datetime import datetime, timezone, timedelta
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
+from urllib.parse import quote
 import requests
 import logging
+from django.core.cache import cache
 from icalendar import Calendar
 from dateutil import parser
 from django.utils import timezone as django_timezone
 import recurring_ical_events
 
 logger = logging.getLogger(__name__)
+
+
+def ical_url(calendar_id: str) -> str:
+    """The public iCal feed of a Google calendar.
+
+    One place builds this address, because three things now depend on its
+    exact shape: the two event endpoints, and the feed we hand to people
+    subscribing at gdzienawesta.com.
+    """
+    return (
+        'https://calendar.google.com/calendar/ical/'
+        f'{quote(calendar_id, safe="")}/public/basic.ics'
+    )
+
+
+class CalendarFeedService:
+    """Google's iCal feed for a city, cached, for handing on to subscribers.
+
+    Standing between a subscriber and Google is a promise: a calendar app that
+    subscribed to gdzienawesta.com asks us, not Google, so when we answer
+    badly its owner sees an empty week. Two things keep that promise.
+
+    The fresh copy spares Google the polling. Every subscribed calendar app
+    refreshes on its own schedule, and without a cache each one of them would
+    become a request to Google; with it, they share one fetch per quarter of
+    an hour, which is far more often than a dance calendar changes.
+
+    The last good copy answers when Google does not. A feed that is minutes
+    stale is a calendar nobody notices; a feed that is briefly missing is
+    events disappearing from someone's phone.
+    """
+
+    FRESH_SECONDS = 15 * 60
+    LAST_GOOD_SECONDS = 7 * 24 * 60 * 60
+    TIMEOUT_SECONDS = 10
+
+    def get(self, calendar_id: str) -> Tuple[Optional[bytes], bool]:
+        """Return (feed, is_stale). ``feed`` is None only if we never had one."""
+        fresh_key = f'ics:fresh:{calendar_id}'
+        last_good_key = f'ics:last-good:{calendar_id}'
+
+        cached = cache.get(fresh_key)
+        if cached is not None:
+            return cached, False
+
+        body = self._fetch(calendar_id)
+        if body is not None:
+            cache.set(fresh_key, body, self.FRESH_SECONDS)
+            cache.set(last_good_key, body, self.LAST_GOOD_SECONDS)
+            return body, False
+
+        last_good = cache.get(last_good_key)
+        if last_good is not None:
+            logger.warning(
+                f'Serving a stale feed for {calendar_id}: Google is unreachable'
+            )
+            return last_good, True
+
+        return None, False
+
+    def _fetch(self, calendar_id: str) -> Optional[bytes]:
+        try:
+            response = requests.get(ical_url(calendar_id), timeout=self.TIMEOUT_SECONDS)
+        except requests.RequestException as exc:
+            logger.error(f'Failed to fetch feed {calendar_id}: {exc}')
+            return None
+
+        if response.status_code != 200:
+            logger.error(
+                f'Failed to fetch feed {calendar_id}: {response.status_code}'
+            )
+            return None
+
+        # A calendar Google has stopped publishing answers 200 with a login
+        # page. Handing that to a subscriber would replace their events with
+        # HTML, and caching it would keep doing so for a week.
+        if not response.content.lstrip().startswith(b'BEGIN:VCALENDAR'):
+            logger.error(f'Feed {calendar_id} did not come back as a calendar')
+            return None
+
+        return response.content
 
 
 class GoogleCalendarService:
@@ -24,17 +107,18 @@ class GoogleCalendarService:
             Dictionary with event data or None if no events found
         """
         try:
-            # Use public iCal feed - no authentication needed!
-            ical_url = f"https://calendar.google.com/calendar/ical/{calendar_id}/public/basic.ics"
+            # The same cached copy the subscription feed hands out. Without it
+            # every visit to the site was its own request to Google, from the
+            # server's single address; now the whole site, every visitor and
+            # every subscriber share one fetch per calendar per quarter hour.
+            feed, _ = CalendarFeedService().get(calendar_id)
 
-            response = requests.get(ical_url, timeout=10)
-
-            if response.status_code != 200:
-                logger.error(f"Failed to fetch calendar {calendar_id}: {response.status_code}")
+            if feed is None:
+                logger.error(f"Failed to fetch calendar {calendar_id}")
                 return None
 
             # Parse iCal data
-            cal = Calendar.from_ical(response.content)
+            cal = Calendar.from_ical(feed)
 
             # Use Django's configured timezone (from settings.TIME_ZONE)
             now = django_timezone.now()
@@ -155,16 +239,15 @@ class GoogleCalendarService:
 
         for calendar_id in calendar_ids:
             try:
-                # Use public iCal feed
-                ical_url = f"https://calendar.google.com/calendar/ical/{calendar_id}/public/basic.ics"
-                response = requests.get(ical_url, timeout=10)
+                # Shared with the subscription feed; see get_next_event().
+                feed, _ = CalendarFeedService().get(calendar_id)
 
-                if response.status_code != 200:
-                    logger.error(f"Failed to fetch calendar {calendar_id}: {response.status_code}")
+                if feed is None:
+                    logger.error(f"Failed to fetch calendar {calendar_id}")
                     continue
 
                 # Parse iCal data
-                cal = Calendar.from_ical(response.content)
+                cal = Calendar.from_ical(feed)
                 now = django_timezone.now()
 
                 # Get all events for the next year

--- a/backend/events/tests.py
+++ b/backend/events/tests.py
@@ -1,7 +1,12 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+from datetime import timedelta
+
+import requests
+from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from .middleware import resolve_city
 from .models import City
@@ -179,10 +184,119 @@ class ApiScopingTests(TestCase):
         self.assertEqual(response.json()['error'], 'No active cities')
 
 
-class CalendarRedirectTests(TestCase):
-    """The four paths that used to be hardcoded in nginx.prod.conf."""
+# A real enough calendar: the event endpoints parse this too, so it needs a
+# date, and one inside the year ahead that those endpoints look at.
+_START = timezone.now() + timedelta(days=30)
+ICS = (
+    'BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\n'
+    'BEGIN:VEVENT\r\nUID:praktis-1\r\nDTSTAMP:20260101T000000Z\r\n'
+    f'DTSTART:{_START.strftime("%Y%m%dT%H%M%SZ")}\r\n'
+    f'DTEND:{(_START + timedelta(hours=3)).strftime("%Y%m%dT%H%M%SZ")}\r\n'
+    'SUMMARY:Praktis\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n'
+).encode()
 
-    PATHS = ['/kalendarz', '/kalendarz/', '/calendar', '/calendar/']
+
+def _google_says(body=ICS, status=200):
+    response = Mock()
+    response.status_code = status
+    response.content = body
+    return response
+
+
+@override_settings(CACHES={'default': {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}})
+class CalendarFeedTests(TestCase):
+    """The feed people subscribe to. These paths used to redirect to Google."""
+
+    PATHS = ['/kalendarz.ics', '/calendar.ics']
+
+    def setUp(self):
+        cache.clear()
+        self.warsaw = City.objects.create(
+            name='Warszawa',
+            calendar_id='warsawwestiesdance@gmail.com',
+            is_default=True,
+        )
+        self.lodz = City.objects.create(name='Łódź', calendar_id='lodz@example.com')
+
+    def test_apex_serves_the_default_city_calendar(self):
+        for path in self.PATHS:
+            cache.clear()
+            with patch('events.services.requests.get', return_value=_google_says()) as get:
+                response = self.client.get(path, HTTP_HOST='gdzienawesta.com')
+            self.assertEqual(response.status_code, 200, path)
+            self.assertEqual(response.content, ICS, path)
+            self.assertEqual(
+                response['Content-Type'], 'text/calendar; charset=utf-8', path
+            )
+            self.assertIn('warsawwestiesdance%40gmail.com', get.call_args[0][0], path)
+
+    def test_subdomain_serves_its_own_calendar(self):
+        with patch('events.services.requests.get', return_value=_google_says()) as get:
+            response = self.client.get('/kalendarz.ics', HTTP_HOST='lodz.gdzienawesta.com')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('lodz%40example.com', get.call_args[0][0])
+        self.assertIn('lodz.ics', response['Content-Disposition'])
+
+    def test_unknown_city_gets_a_404(self):
+        for path in self.PATHS:
+            response = self.client.get(path, HTTP_HOST='krakow.gdzienawesta.com')
+            self.assertEqual(response.status_code, 404, path)
+
+    def test_subscribers_share_one_fetch(self):
+        """Every subscribed calendar app polls on its own; Google sees one."""
+        with patch('events.services.requests.get', return_value=_google_says()) as get:
+            for _ in range(5):
+                self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+        self.assertEqual(get.call_count, 1)
+
+    def test_the_site_and_the_feed_share_one_fetch(self):
+        """The page used to go to Google on every single visit."""
+        with patch('events.services.requests.get', return_value=_google_says()) as get:
+            events = self.client.get('/api/next-events/', HTTP_HOST='gdzienawesta.com')
+            feed = self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+
+        self.assertEqual(get.call_count, 1)
+        self.assertEqual(events.status_code, 200)
+        self.assertEqual(events.json()['events'][0]['title'], 'Praktis')
+        self.assertEqual(feed.content, ICS)
+
+    def test_each_city_is_cached_separately(self):
+        with patch('events.services.requests.get', return_value=_google_says()) as get:
+            self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+            self.client.get('/kalendarz.ics', HTTP_HOST='lodz.gdzienawesta.com')
+        self.assertEqual(get.call_count, 2)
+
+    def test_last_good_copy_answers_when_google_is_down(self):
+        with patch('events.services.requests.get', return_value=_google_says()):
+            self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+
+        cache.delete('ics:fresh:warsawwestiesdance@gmail.com')
+        with patch('events.services.requests.get', side_effect=requests.Timeout()):
+            response = self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, ICS)
+        self.assertEqual(response['X-Feed-Stale'], '1')
+
+    def test_no_copy_at_all_is_an_error_not_an_empty_calendar(self):
+        """An empty calendar reads as "everything was cancelled" to a subscriber."""
+        with patch('events.services.requests.get', side_effect=requests.Timeout()):
+            response = self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+        self.assertEqual(response.status_code, 502)
+
+    def test_a_login_page_is_neither_served_nor_cached(self):
+        """A calendar Google stopped publishing answers 200 with HTML."""
+        with patch('events.services.requests.get', return_value=_google_says(b'<html>Sign in')):
+            response = self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+        self.assertEqual(response.status_code, 502)
+
+        with patch('events.services.requests.get', return_value=_google_says()):
+            response = self.client.get('/kalendarz.ics', HTTP_HOST='gdzienawesta.com')
+        self.assertEqual(response.content, ICS)
+
+
+class CalendarInfoTests(TestCase):
+    """Feeds the calendar page: which city, which calendar, where Google is."""
 
     def setUp(self):
         self.warsaw = City.objects.create(
@@ -192,32 +306,25 @@ class CalendarRedirectTests(TestCase):
         )
         self.lodz = City.objects.create(name='Łódź', calendar_id='lodz@example.com')
 
-    def test_apex_target_is_unchanged(self):
-        """Byte for byte what nginx returned before this moved into Django."""
-        expected = (
+    def test_google_link_is_what_the_redirect_used_to_point_at(self):
+        """Byte for byte the address nginx, and then Django, redirected to."""
+        data = self.client.get('/api/calendar/', HTTP_HOST='gdzienawesta.com').json()
+        self.assertEqual(
+            data['google_url'],
             'https://calendar.google.com/calendar/embed'
-            '?src=warsawwestiesdance%40gmail.com&ctz=Europe%2FWarsaw'
+            '?src=warsawwestiesdance%40gmail.com&ctz=Europe%2FWarsaw',
         )
-        for path in self.PATHS:
-            response = self.client.get(path, HTTP_HOST='gdzienawesta.com')
-            self.assertEqual(response.status_code, 302, path)
-            self.assertEqual(response['Location'], expected, path)
+        self.assertEqual(data['city']['name'], 'Warszawa')
 
-    def test_subdomain_points_at_its_own_calendar(self):
-        for path in self.PATHS:
-            response = self.client.get(path, HTTP_HOST='lodz.gdzienawesta.com')
-            self.assertEqual(response.status_code, 302, path)
-            self.assertIn('lodz%40example.com', response['Location'], path)
+    def test_subdomain_describes_its_own_city(self):
+        data = self.client.get('/api/calendar/', HTTP_HOST='lodz.gdzienawesta.com').json()
+        self.assertEqual(data['city']['slug'], 'lodz')
+        self.assertEqual(data['calendar_id'], 'lodz@example.com')
 
-    def test_no_redirect_chain_on_the_slashless_form(self):
-        """APPEND_SLASH must not bounce /kalendarz to /kalendarz/ first."""
-        response = self.client.get('/kalendarz', HTTP_HOST='gdzienawesta.com')
-        self.assertTrue(response['Location'].startswith('https://calendar.google.com'))
-
-    def test_unknown_city_gets_a_404(self):
-        for path in self.PATHS:
-            response = self.client.get(path, HTTP_HOST='krakow.gdzienawesta.com')
-            self.assertEqual(response.status_code, 404, path)
+    def test_unknown_city_gets_the_shared_404(self):
+        response = self.client.get('/api/calendar/', HTTP_HOST='krakow.gdzienawesta.com')
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()['error'], 'Unknown city')
 
 
 class CitiesEndpointTests(TestCase):

--- a/backend/events/urls.py
+++ b/backend/events/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import CitiesView, NextEventView, NextEventsView
+from .views import CalendarInfoView, CitiesView, NextEventView, NextEventsView
 
 urlpatterns = [
     path('next-event/', NextEventView.as_view(), name='next-event'),
     path('next-events/', NextEventsView.as_view(), name='next-events'),
     path('cities/', CitiesView.as_view(), name='cities'),
+    path('calendar/', CalendarInfoView.as_view(), name='calendar-info'),
 ]

--- a/backend/events/views.py
+++ b/backend/events/views.py
@@ -1,8 +1,8 @@
 from urllib.parse import quote
 
-from django.http import HttpResponseNotFound, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from django.views import View
-from .services import GoogleCalendarService
+from .services import CalendarFeedService, GoogleCalendarService
 import logging
 
 logger = logging.getLogger(__name__)
@@ -100,32 +100,79 @@ class NextEventsView(View):
             }, status=500)
 
 
-class CalendarRedirectView(View):
-    """Send /kalendarz and /calendar to the city's Google Calendar.
+# Every city we serve is in Poland; kept as it was in the nginx config that
+# first hardcoded Warsaw's calendar into a redirect.
+DISPLAY_TIMEZONE = 'Europe/Warsaw'
 
-    These four paths used to be `return 302` blocks in nginx.prod.conf with
-    Warsaw's calendar written into them. They live here now so that adding a
-    city in the admin panel gives it a working calendar address too, instead
-    of a page that works and a link that does not.
+
+def _google_embed_url(city):
+    """Google's own page for this calendar, still worth linking to.
+
+    safe='' matters: quote() leaves "/" alone by default, and this address has
+    carried the timezone as Europe%2FWarsaw since it lived in nginx.
     """
+    return (
+        'https://calendar.google.com/calendar/embed'
+        f'?src={quote(city.calendar_id, safe="")}'
+        f'&ctz={quote(DISPLAY_TIMEZONE, safe="")}'
+    )
 
-    # Every city we serve is in Poland; kept as it was in the nginx config.
-    DISPLAY_TIMEZONE = 'Europe/Warsaw'
+
+class CalendarFeedView(View):
+    """The city's calendar as an iCal feed: /kalendarz.ics and /calendar.ics.
+
+    These paths used to redirect a visitor to Google. Serving the calendar
+    ourselves makes the address people subscribe to ours, which is what lets
+    the calendar behind a city change without every subscriber having to
+    resubscribe - and lets bootstrap.json name gdzienawesta.com rather than a
+    Google calendar id.
+
+    The caching, and the promise it keeps, live in CalendarFeedService.
+    """
 
     def get(self, request):
         city = getattr(request, 'city', None)
         if city is None:
-            # Step 5.4 replaces this with the page listing the cities we do
-            # serve; a bare response keeps the shape right until then.
             return HttpResponseNotFound('No city is served at this address\n')
 
-        # safe='' matters: quote() leaves "/" alone by default, and the target
-        # nginx used carried the timezone as Europe%2FWarsaw.
-        return HttpResponseRedirect(
-            'https://calendar.google.com/calendar/embed'
-            f'?src={quote(city.calendar_id, safe="")}'
-            f'&ctz={quote(self.DISPLAY_TIMEZONE, safe="")}'
-        )
+        feed, is_stale = CalendarFeedService().get(city.calendar_id)
+        if feed is None:
+            # No copy at all, fresh or stale. Saying so beats answering with
+            # an empty calendar, which a subscriber's app would take as "every
+            # event was cancelled" and act on.
+            return HttpResponse(
+                'Calendar temporarily unavailable\n',
+                status=502,
+                content_type='text/plain; charset=utf-8',
+            )
+
+        response = HttpResponse(feed, content_type='text/calendar; charset=utf-8')
+        # inline, not attachment: a browser that follows this link should be
+        # able to hand it straight to the calendar app.
+        response['Content-Disposition'] = f'inline; filename="{city.slug}.ics"'
+        response['Cache-Control'] = f'public, max-age={CalendarFeedService.FRESH_SECONDS}'
+        if is_stale:
+            # Invisible to subscribers, but it turns "did the feed update?"
+            # into something a single curl can answer.
+            response['X-Feed-Stale'] = '1'
+        return response
+
+
+class CalendarInfoView(View):
+    """What the calendar page needs to know about the city it is showing."""
+
+    def get(self, request):
+        city = getattr(request, 'city', None)
+        if city is None:
+            return _no_city_response(request)
+
+        return JsonResponse({
+            'success': True,
+            'city': {'name': city.name, 'slug': city.slug},
+            'calendar_id': city.calendar_id,
+            'timezone': DISPLAY_TIMEZONE,
+            'google_url': _google_embed_url(city),
+        })
 
 
 class CitiesView(View):

--- a/backend/westnfound/settings.py
+++ b/backend/westnfound/settings.py
@@ -105,6 +105,16 @@ STATIC_ROOT = BASE_DIR / 'staticfiles'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# Where the cached calendar feed lives. File based rather than in memory
+# because gunicorn runs four workers: a per-process cache would mean four
+# copies of every calendar and four times the polling of Google.
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.filebased.FileBasedCache',
+        'LOCATION': os.environ.get('CACHE_DIR', '/tmp/westnfound-cache'),
+    }
+}
+
 # CORS settings
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_CREDENTIALS = True

--- a/backend/westnfound/urls.py
+++ b/backend/westnfound/urls.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.urls import path, include
 import os
 
-from events.views import CalendarRedirectView
+from events.views import CalendarFeedView
 
 # Get admin URL from environment variable (default: 'admin')
 ADMIN_URL = os.environ.get('DJANGO_ADMIN_URL', 'admin').strip('/')
@@ -13,10 +13,9 @@ ADMIN_URL = os.environ.get('DJANGO_ADMIN_URL', 'admin').strip('/')
 urlpatterns = [
     path(f'{ADMIN_URL}/', admin.site.urls),
     path('api/', include('events.urls')),
-    # Both spellings, with and without the trailing slash, so no visitor gets
-    # bounced through a redirect on the way to a redirect.
-    path('kalendarz', CalendarRedirectView.as_view(), name='calendar-redirect-pl'),
-    path('kalendarz/', CalendarRedirectView.as_view()),
-    path('calendar', CalendarRedirectView.as_view(), name='calendar-redirect-en'),
-    path('calendar/', CalendarRedirectView.as_view()),
+    # The subscribable feed, in both spellings. /kalendarz and /calendar
+    # without the extension are the human page, served by nginx from the
+    # frontend - they never reach Django.
+    path('kalendarz.ics', CalendarFeedView.as_view(), name='calendar-feed-pl'),
+    path('calendar.ics', CalendarFeedView.as_view(), name='calendar-feed-en'),
 ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,13 @@ on the subdomain it was asked on.
 Times are ISO 8601 with a UTC offset; the frontend renders them in the
 visitor's own timezone.
 
+Every endpoint that needs a calendar reads the same cached copy of it,
+the one the subscription feed hands out. Requests to Google all leave from the
+server's single address, so without that the site's traffic to Google grew
+with its own popularity: one fetch per visit, plus one per open tab every five
+minutes. Now it is one fetch per calendar every 15 minutes no matter how busy
+the site is - at the price of a calendar edit taking that long to show up.
+
 ## GET /api/next-events/
 
 The next few events for this city.
@@ -65,11 +72,30 @@ Every active city, for the footer and the unknown-city page.
   on an `https://` page.
 - `current` is `null` when the host names no city we serve.
 
-## GET /kalendarz, /calendar
+## GET /api/calendar/
 
-Redirect (302) to this city's Google Calendar embed. Both spellings work, with
-and without a trailing slash, and none of the four bounces through an
-intermediate redirect.
+What the calendar page needs about the city it is showing: `city`
+(`name`, `slug`), `calendar_id`, `timezone` and `google_url` — the address of
+this calendar on Google, still worth offering as a link.
+
+## GET /kalendarz.ics, /calendar.ics
+
+This city's calendar as an iCal feed, `text/calendar`, for anyone subscribing
+in their own calendar app. Both spellings serve the same thing.
+
+The body is Google's own feed passed through, cached for 15 minutes: every
+subscribed calendar app polls on its own schedule, and without the cache each
+poll would become a request to Google. The last good copy is kept for a week
+and answered with when Google is unreachable — a feed that is stale by minutes
+goes unnoticed, while a feed that is briefly missing empties someone's
+calendar. A stale answer carries `X-Feed-Stale: 1`.
+
+`502` means we have no copy at all, fresh or stale. It is deliberately not an
+empty calendar, which a subscriber's app would read as every event having been
+cancelled.
+
+`/kalendarz` and `/calendar` (without the extension) are the human page and
+never reach Django — nginx serves them from the frontend.
 
 ## Errors
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -78,8 +78,8 @@ docker compose --profile prod up -d --build
 python3 scripts/stamp-assets.py
 ```
 
-`stamp-assets.py` rewrites the asset links in `index.html` with a hash of each
-file's contents. **It is not optional.** nginx serves CSS and JS with
+`stamp-assets.py` rewrites the asset links in every page under `frontend/`
+with a hash of each file's contents. **It is not optional.** nginx serves CSS and JS with
 `expires 1y` and `Cache-Control: immutable`, while the HTML document is not
 cached — so without it a returning visitor gets new markup with last year's
 JavaScript. Because the version is a content hash, files you did not touch
@@ -87,9 +87,11 @@ keep their URLs and stay cached.
 
 Re-running the script is safe; an existing `?v=` is replaced, not appended to.
 
-If your deployment injects anything into `index.html` after checkout —
+If your deployment injects anything into the pages after checkout —
 analytics, for instance, from a script kept out of the repository — run it in
-the same step. Order does not matter.
+the same step. Order does not matter. Such a script wants checking whenever a
+page is added: one written when `index.html` was the only page will silently
+skip the new one.
 
 ## Management
 

--- a/frontend/calendar.html
+++ b/frontend/calendar.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gdzie na Westa? - Kalendarz</title>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <link rel="stylesheet" href="styles.css?v=9db47249">
+</head>
+<body>
+    <div class="container container-wide" x-data="calendarPage()" x-init="init()">
+        <!-- Header -->
+        <header class="header">
+            <div class="language-switcher language-switcher-desktop">
+                <button @click="setLanguage('pl')" :class="{ active: currentLang === 'pl' }" class="lang-btn">PL</button>
+                <button @click="setLanguage('en')" :class="{ active: currentLang === 'en' }" class="lang-btn">EN</button>
+            </div>
+            <h1 x-text="t('calendarTitle')"></h1>
+            <p class="subtitle">
+                <span x-text="t('calendarSubtitle')"></span><template x-if="city"><span> &middot; <span class="city-current" x-text="city.name"></span></span></template>
+            </p>
+        </header>
+
+        <!-- Loading State -->
+        <div x-show="loading" class="loading">
+            <div class="spinner"></div>
+            <p x-text="t('calendarLoading')"></p>
+        </div>
+
+        <!-- Unknown City State -->
+        <div x-show="unknownCity && !loading" class="error-card">
+            <div class="language-switcher language-switcher-mobile">
+                <button @click="setLanguage('pl')" :class="{ active: currentLang === 'pl' }" class="lang-btn">PL</button>
+                <button @click="setLanguage('en')" :class="{ active: currentLang === 'en' }" class="lang-btn">EN</button>
+            </div>
+            <div class="error-icon">🗺️</div>
+            <h2 x-text="t('unknownCityTitle')"></h2>
+            <p x-text="t('unknownCityBody')"></p>
+            <p class="city-list" x-show="cities.length">
+                <template x-for="(otherCity, index) in cities" :key="otherCity.slug">
+                    <span>
+                        <a :href="otherCity.url + '/' + t('calendarPath')" x-text="otherCity.name"></a><span x-show="index < cities.length - 1"> · </span>
+                    </span>
+                </template>
+            </p>
+            <p class="city-add">
+                <a href="https://app.gdzienawesta.com/add-your-city.html" x-text="t('addYourCity')"></a>
+            </p>
+        </div>
+
+        <!-- Error State -->
+        <div x-show="error && !loading" class="error-card">
+            <div class="error-icon">⚠️</div>
+            <h2 x-text="t('errorTitle')"></h2>
+            <p x-text="t('errorDefault')"></p>
+            <button @click="load()" class="retry-btn" x-text="t('retryButton')"></button>
+        </div>
+
+        <!-- Calendar -->
+        <div x-show="city && !loading && !error && !unknownCity" class="calendar-card">
+            <!-- Subscribing is the point of this page; the preview only proves
+                 there is something worth subscribing to. -->
+            <div class="subscribe-row">
+                <a :href="webcalUrl" class="retry-btn subscribe-btn" x-text="t('calendarSubscribe')"></a>
+                <button @click="copyFeedUrl()" class="action-btn" x-text="copied ? t('calendarCopied') : t('calendarCopy')"></button>
+                <a :href="googleUrl" target="_blank" rel="noopener" class="action-btn" x-text="t('calendarOpenGoogle')"></a>
+            </div>
+            <p class="subscribe-hint" x-text="t('calendarSubscribeHint')"></p>
+            <p class="subscribe-address" x-text="feedUrl"></p>
+
+            <div class="calendar-frame">
+                <iframe
+                    :src="embedSrc"
+                    :title="t('calendarTitle')"
+                    frameborder="0"
+                    scrolling="no"
+                    loading="lazy"></iframe>
+            </div>
+        </div>
+
+        <!-- Footer -->
+        <footer class="footer">
+            <p class="footer-links">
+                <a href="/" x-text="t('calendarBackToEvents')"></a> &middot;
+                <a href="https://app.gdzienawesta.com" target="_blank" rel="noopener" x-text="t('footerApp')"></a> &middot;
+                <a href="https://app.gdzienawesta.com/add-your-city.html" target="_blank" rel="noopener" x-text="t('addYourCity')"></a>
+            </p>
+            <p class="footer-timezone" x-text="t('timezone')"></p>
+        </footer>
+    </div>
+
+    <script src="translations.js?v=63498f5e"></script>
+    <script src="calendar.js?v=6b301b5f"></script>
+</body>
+</html>

--- a/frontend/calendar.js
+++ b/frontend/calendar.js
@@ -1,0 +1,157 @@
+function calendarPage() {
+    return {
+        loading: true,
+        error: false,
+        unknownCity: false,
+        currentLang: 'pl',
+        city: null,
+        cities: [],
+        calendarId: '',
+        timezone: 'Europe/Warsaw',
+        googleUrl: '',
+        copied: false,
+        // A month grid on a phone is a wall of coloured slivers; the agenda
+        // view is the same calendar, readable. Which one applies is decided
+        // once and only revisited when the window crosses the threshold, so
+        // dragging a window edge does not reload the calendar on every pixel.
+        NARROW_PX: 700,
+        isNarrow: false,
+        FETCH_TIMEOUT_MS: 15 * 1000,
+
+        get feedUrl() {
+            return `${location.origin}/${this.t('calendarPath')}.ics`;
+        },
+
+        get webcalUrl() {
+            // webcal:// is what makes a calendar app offer to subscribe
+            // instead of a browser offering to download. Nothing serves it -
+            // the app rewrites it back to https before asking us.
+            return this.feedUrl.replace(/^https?:/, 'webcal:');
+        },
+
+        get embedSrc() {
+            if (!this.calendarId) return '';
+            const params = new URLSearchParams({
+                src: this.calendarId,
+                ctz: this.timezone,
+                mode: this.isNarrow ? 'AGENDA' : 'MONTH',
+                // We already say whose calendar this is, in our own words.
+                showTitle: '0',
+                showPrint: '0',
+                showTz: '0',
+                showCalendars: '0',
+                wkst: '2',              // weeks start on Monday in Poland
+                hl: this.currentLang,
+            });
+            return `https://calendar.google.com/calendar/embed?${params.toString()}`;
+        },
+
+        init() {
+            this.initLanguage();
+            this.isNarrow = window.innerWidth < this.NARROW_PX;
+            this.load();
+            this.loadCities();
+
+            window.addEventListener('resize', () => {
+                const narrow = window.innerWidth < this.NARROW_PX;
+                if (narrow !== this.isNarrow) this.isNarrow = narrow;
+            });
+        },
+
+        initLanguage() {
+            const savedLang = localStorage.getItem('preferredLanguage');
+            if (savedLang && translations[savedLang]) {
+                this.currentLang = savedLang;
+            } else {
+                const browserLang = navigator.language.split('-')[0];
+                this.currentLang = translations[browserLang] ? browserLang : 'pl';
+            }
+            this.updateHtmlLang();
+        },
+
+        setLanguage(lang) {
+            if (translations[lang]) {
+                this.currentLang = lang;
+                localStorage.setItem('preferredLanguage', lang);
+                this.updateHtmlLang();
+                this.updateTitle();
+            }
+        },
+
+        updateHtmlLang() {
+            document.documentElement.lang = this.currentLang;
+        },
+
+        updateTitle() {
+            document.title = this.city
+                ? `${this.t('title')} - ${this.t('calendarTitle')} - ${this.city.name}`
+                : `${this.t('title')} - ${this.t('calendarTitle')}`;
+        },
+
+        t(key) {
+            return translations[this.currentLang]?.[key] || key;
+        },
+
+        async load() {
+            this.loading = true;
+            this.error = false;
+            this.unknownCity = false;
+
+            // fetch() on its own waits forever; a request that left as the
+            // network went away would leave this page on its spinner.
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), this.FETCH_TIMEOUT_MS);
+            try {
+                const response = await fetch('/api/calendar/', { signal: controller.signal });
+                const data = await response.json();
+
+                if (response.status === 404) {
+                    this.unknownCity = true;
+                    return;
+                }
+                if (!response.ok || !data.success) {
+                    this.error = true;
+                    return;
+                }
+
+                this.city = data.city;
+                this.calendarId = data.calendar_id;
+                this.timezone = data.timezone;
+                this.googleUrl = data.google_url;
+                this.updateTitle();
+            } catch (err) {
+                console.error('Error loading calendar:', err);
+                this.error = true;
+            } finally {
+                clearTimeout(timer);
+                this.loading = false;
+            }
+        },
+
+        async loadCities() {
+            // Only the unknown-city card uses these, and it is the one case
+            // where the request above has already failed - so this one stands
+            // on its own and stays silent when it cannot deliver.
+            try {
+                const response = await fetch('/api/cities/');
+                const data = await response.json();
+                this.cities = data.cities || [];
+            } catch (err) {
+                console.error('Error loading cities:', err);
+            }
+        },
+
+        async copyFeedUrl() {
+            try {
+                await navigator.clipboard.writeText(this.feedUrl);
+                this.copied = true;
+                setTimeout(() => { this.copied = false; }, 2000);
+            } catch (err) {
+                // Clipboard access can be refused outright (no permission, or
+                // an insecure origin). The address is printed under the
+                // buttons precisely so there is always a way to get it.
+                console.error('Error copying the feed address:', err);
+            }
+        },
+    };
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gdzie na Westa? - Najbliższe Wydarzenie</title>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="styles.css?v=9db47249">
 </head>
 <body>
     <div class="container" x-data="eventApp()" x-init="init()">
@@ -157,7 +157,7 @@
         </footer>
     </div>
 
-    <script src="translations.js"></script>
-    <script src="app.js"></script>
+    <script src="translations.js?v=63498f5e"></script>
+    <script src="app.js?v=3fb3e000"></script>
 </body>
 </html>

--- a/frontend/nginx.dev.conf
+++ b/frontend/nginx.dev.conf
@@ -4,18 +4,33 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Redirect calendar shortcuts to Google Calendar embed
-    location = /calendar {
-        return 302 https://calendar.google.com/calendar/embed?src=warsawwestiesdance%40gmail.com&ctz=Europe%2FWarsaw;
-    }
-    location = /calendar/ {
-        return 302 https://calendar.google.com/calendar/embed?src=warsawwestiesdance%40gmail.com&ctz=Europe%2FWarsaw;
-    }
+    # Calendar page and the feed behind it. These used to be four redirects
+    # with Warsaw's calendar written in, from before cities existed.
     location = /kalendarz {
-        return 302 https://calendar.google.com/calendar/embed?src=warsawwestiesdance%40gmail.com&ctz=Europe%2FWarsaw;
+        try_files /calendar.html =404;
     }
     location = /kalendarz/ {
-        return 302 https://calendar.google.com/calendar/embed?src=warsawwestiesdance%40gmail.com&ctz=Europe%2FWarsaw;
+        try_files /calendar.html =404;
+    }
+    location = /calendar {
+        try_files /calendar.html =404;
+    }
+    location = /calendar/ {
+        try_files /calendar.html =404;
+    }
+
+    # The page's own file name is not one of its addresses - it is reachable
+    # through the four paths above and nowhere else.
+    location = /calendar.html {
+        return 404;
+    }
+
+    location ~ ^/(kalendarz|calendar)\.ics$ {
+        proxy_pass http://backend-dev:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 
     location / {

--- a/frontend/nginx.prod.conf
+++ b/frontend/nginx.prod.conf
@@ -4,33 +4,39 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Calendar shortcuts. These used to be four `return 302` blocks with
-    # Warsaw's calendar written in; the target now depends on which city the
-    # Host header names, which only Django knows. The regex location further
-    # down already catches /kalendarz/ with a trailing slash - these are
-    # spelled out so that the versions without one behave the same.
-    location = /calendar {
-        proxy_pass http://backend-prod:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-    location = /calendar/ {
-        proxy_pass http://backend-prod:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
+    # The calendar lives on this domain now. /kalendarz and /calendar are a
+    # page a person can read; the .ics addresses next to them are the feed a
+    # calendar app subscribes to, which only Django can build - it has to know
+    # which city the Host header names. All four page spellings are exact
+    # matches on purpose: the regex location further down would otherwise
+    # catch /kalendarz/ and send it to Django's admin panel.
     location = /kalendarz {
-        proxy_pass http://backend-prod:8000;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        try_files /calendar.html =404;
     }
     location = /kalendarz/ {
+        try_files /calendar.html =404;
+    }
+    location = /calendar {
+        try_files /calendar.html =404;
+    }
+    location = /calendar/ {
+        try_files /calendar.html =404;
+    }
+
+    # The page's own file name is not one of its addresses - it is reachable
+    # through the four paths above and nowhere else.
+    location = /calendar.html {
+        return 404;
+    }
+
+    location = /kalendarz.ics {
+        proxy_pass http://backend-prod:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+    location = /calendar.ics {
         proxy_pass http://backend-prod:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -849,3 +849,91 @@ body {
 .footer-fineprint .footer-links {
     margin-top: 0 !important;
 }
+
+/* Calendar page: the feed to subscribe to, with the calendar itself as proof
+   there is something behind it. A month grid needs more width than a single
+   event card, so the container is wider here than on the event page. */
+.container-wide {
+    max-width: 1100px;
+}
+
+.calendar-card {
+    background: var(--bg-white);
+    border-radius: 20px;
+    padding: 30px;
+    box-shadow: var(--shadow-lg);
+    animation: fadeIn 0.6s ease-out;
+}
+
+.subscribe-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+}
+
+/* The subscribe button is an anchor, not a button: webcal:// has to be a
+   link for the calendar app to be offered it. */
+.subscribe-btn {
+    display: inline-block;
+    text-decoration: none;
+}
+
+.subscribe-row .action-btn {
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+}
+
+.subscribe-hint {
+    text-align: center;
+    color: var(--text-secondary);
+    margin-top: 16px;
+}
+
+/* The address in plain sight, so copying it never depends on the clipboard
+   button working - it can be refused by the browser outright. */
+.subscribe-address {
+    text-align: center;
+    margin-top: 8px;
+    margin-bottom: 24px;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    word-break: break-all;
+    user-select: all;
+}
+
+.calendar-frame {
+    position: relative;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    height: 70vh;
+    min-height: 420px;
+}
+
+.calendar-frame iframe {
+    width: 100%;
+    height: 100%;
+    border: 0;
+    display: block;
+}
+
+@media (max-width: 768px) {
+    .calendar-card {
+        padding: 20px;
+    }
+
+    /* The agenda view is a list; it needs length rather than a viewport
+       share, and a phone's viewport share is not much. */
+    .calendar-frame {
+        height: auto;
+        min-height: 0;
+    }
+
+    .calendar-frame iframe {
+        height: 65vh;
+        min-height: 380px;
+    }
+}

--- a/frontend/translations.js
+++ b/frontend/translations.js
@@ -41,10 +41,21 @@ const translations = {
         footerCode: "Kod dostępny na",
         footerFeedback: "Masz pomysł lub uwagę?",
         footerReport: "Zgłoś tutaj",
-        footerCalendarDirect: "Bezpośredni link do kalendarza",
+        footerCalendarDirect: "Kalendarz",
         footerApp: "Aplikacja na telefon",
         footerThanks: "Podziękowania",
         calendarPath: "kalendarz",
+
+        // Calendar page
+        calendarTitle: "Kalendarz",
+        calendarSubtitle: "Wszystkie wydarzenia w jednym miejscu",
+        calendarLoading: "Ładowanie kalendarza...",
+        calendarSubscribe: "📅 Subskrybuj kalendarz",
+        calendarCopy: "🔗 Skopiuj adres",
+        calendarCopied: "✓ Skopiowano",
+        calendarOpenGoogle: "Otwórz w Google Calendar",
+        calendarSubscribeHint: "Dodaj ten kalendarz do telefonu albo komputera — nowe wydarzenia będą się w nim pojawiać same.",
+        calendarBackToEvents: "← Najbliższe wydarzenia",
 
         // Language
         language: "Język",
@@ -95,10 +106,21 @@ const translations = {
         footerCode: "Code available on",
         footerFeedback: "Have an idea or feedback?",
         footerReport: "Report here",
-        footerCalendarDirect: "Direct calendar link",
+        footerCalendarDirect: "Calendar",
         footerApp: "Mobile app",
         footerThanks: "Thanks",
         calendarPath: "calendar",
+
+        // Calendar page
+        calendarTitle: "Calendar",
+        calendarSubtitle: "Every event in one place",
+        calendarLoading: "Loading calendar...",
+        calendarSubscribe: "📅 Subscribe to calendar",
+        calendarCopy: "🔗 Copy address",
+        calendarCopied: "✓ Copied",
+        calendarOpenGoogle: "Open in Google Calendar",
+        calendarSubscribeHint: "Add this calendar to your phone or computer — new events will keep showing up on their own.",
+        calendarBackToEvents: "← Upcoming events",
 
         // Language
         language: "Language",

--- a/scripts/stamp-assets.py
+++ b/scripts/stamp-assets.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Stamp the frontend asset links in index.html with a content hash.
+"""Stamp the frontend asset links in every page with a content hash.
 
 nginx serves CSS and JS with `expires 1y` and `Cache-Control: immutable`,
 while the HTML document is not cached at all. Without a version in the asset
@@ -11,7 +11,11 @@ The version is a hash of the file's contents, not a timestamp, so a deploy
 that does not touch app.js leaves its URL alone and visitors keep their
 cached copy.
 
-Run from the repository root, after any step that edits index.html:
+Every .html file in frontend/ is stamped, not just index.html: the calendar
+page shares styles.css and translations.js with it, so leaving it out would
+give it exactly the mismatch this script exists to prevent.
+
+Run from the repository root, after any step that edits a page:
 
     python3 scripts/stamp-assets.py
 
@@ -23,37 +27,48 @@ import re
 import sys
 from pathlib import Path
 
-ASSETS = ('styles.css', 'app.js', 'translations.js')
+ASSETS = ('styles.css', 'app.js', 'translations.js', 'calendar.js')
 
 
 def content_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
 
 
-def stamp(frontend: Path) -> list[str]:
-    index = frontend / 'index.html'
-    html = index.read_text(encoding='utf-8')
+def stamp_page(page: Path, versions: dict[str, str]) -> list[str]:
+    html = page.read_text(encoding='utf-8')
     stamped = []
 
-    for asset in ASSETS:
-        asset_path = frontend / asset
-        if not asset_path.exists():
-            print(f'skipping {asset}: not found', file=sys.stderr)
-            continue
-
-        version = content_hash(asset_path)
+    for asset, version in versions.items():
         # Matches href="styles.css" and href="styles.css?v=old" alike, in
         # either quote style, and leaves any other attribute untouched.
         pattern = re.compile(
             r'(["\'])' + re.escape(asset) + r'(?:\?v=[^"\']*)?\1'
         )
         html, count = pattern.subn(rf'\g<1>{asset}?v={version}\g<1>', html)
+        # A page not using an asset is normal now that there is more than one
+        # page; only a page using none of them is worth a word.
         if count:
-            stamped.append(f'{asset} -> {version} ({count}x)')
-        else:
-            print(f'warning: no reference to {asset} in index.html', file=sys.stderr)
+            stamped.append(f'{page.name}: {asset} -> {version} ({count}x)')
 
-    index.write_text(html, encoding='utf-8')
+    page.write_text(html, encoding='utf-8')
+    return stamped
+
+
+def stamp(frontend: Path) -> list[str]:
+    versions = {}
+    for asset in ASSETS:
+        asset_path = frontend / asset
+        if not asset_path.exists():
+            print(f'skipping {asset}: not found', file=sys.stderr)
+            continue
+        versions[asset] = content_hash(asset_path)
+
+    stamped = []
+    for page in sorted(frontend.glob('*.html')):
+        lines = stamp_page(page, versions)
+        if not lines:
+            print(f'warning: {page.name} references no known asset', file=sys.stderr)
+        stamped.extend(lines)
     return stamped
 
 


### PR DESCRIPTION
 `/kalendarz` and `/calendar` used to redirect to Google. They are now a page on  this site, with the same calendar next to it as a subscribable feed.

  ### What changes

  - **`/kalendarz`, `/calendar`** (with or without a trailing slash) — a page showing the city's calendar, with a **Subscribe** button, the feed address in plain sight, and a link to Google for anyone who wants it there. Month grid on a desktop, agenda view on a phone. An unknown subdomain gets the same card the home page shows, listing the cities we do serve.
  - **`/kalendarz.ics`, `/calendar.ics`** — Google's feed for this city, passed through. Subscribers get an address on this domain, so the calendar behind a city can change without anyone having to resubscribe.
  - **One fetch per calendar per 15 minutes**, shared by the pages, the API and the feed. All requests to Google leave from the server's single address, so before this the site's traffic to Google grew with its own popularity: one fetch per visit, plus one per open tab every five minutes. The price is that a calendar edit takes up to 15 minutes to appear.
  - The last good copy is kept for a week and served when Google is unreachable, marked with `X-Feed-Stale: 1`. With no copy at all we answer `502` rather than an empty calendar, which a subscriber's app would read as every event having been cancelled. A login page (Google's `200` for a calendar that stopped being public) is never served and never cached.

  ### Deployment notes

   `scripts/stamp-assets.py` now stamps every page, not just `index.html`.